### PR TITLE
refactor(pyproj): for versions before 2.2.0, prepend "+init=" to epsg…

### DIFF
--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -605,11 +605,15 @@ def test_dis_sr():
                                    rotation=rotation, xul=xul, yul=yul,
                                    proj4_str='epsg:2243')
 
-    if abs(dis.sr.xul - xul) > 0.01:
-        raise AssertionError()
-
-    if abs(dis.sr.yul - yul) > 0.01:
-        raise AssertionError()
+    # SpatialReference has been deprecated
+    # if abs(dis.sr.xul - xul) > 0.01:
+    #     raise AssertionError()
+    # if abs(dis.sr.yul - yul) > 0.01:
+    #     raise AssertionError()
+    # Use StructuredGrid instead
+    x, y = bg.modelgrid.get_coords(0, delc * nrow)
+    np.testing.assert_almost_equal(x, xul)
+    np.testing.assert_almost_equal(y, yul)
 
 
 def test_mg():

--- a/flopy/export/netcdf.py
+++ b/flopy/export/netcdf.py
@@ -733,6 +733,8 @@ class NetCdf(object):
         if pyproj220:
             self.grid_crs = pyproj.CRS(proj4_str)
         else:
+            if proj4_str.lower().startswith("epsg:"):
+                proj4_str = "+init=" + proj4_str
             self.grid_crs = pyproj.Proj(proj4_str, preserve_units=True)
 
         print("initialize_geometry::self.grid_crs = {}".format(self.grid_crs))
@@ -753,7 +755,10 @@ class NetCdf(object):
                 self.grid_crs, nc_crs, always_xy=True
             )
         else:
-            nc_crs = pyproj.Proj(self.nc_epsg_str)
+            nc_epsg_str = self.nc_epsg_str
+            if nc_epsg_str.lower().startswith("epsg:"):
+                nc_epsg_str = "+init=" + nc_epsg_str
+            nc_crs = pyproj.Proj(nc_epsg_str)
             self.transformer = None
 
         print("initialize_geometry::nc_crs = {}".format(nc_crs))

--- a/flopy/utils/reference.py
+++ b/flopy/utils/reference.py
@@ -300,7 +300,7 @@ class SpatialReference(object):
             elif (
                 "units=ft" in proj_str
                 or "units=us-ft" in proj_str
-                or "to_meters:0.3048" in proj_str
+                or "to_meter=0.3048" in proj_str
             ):
                 units = "feet"
             return units


### PR DESCRIPTION
… ids (#1003)

* For test_dis_sr, remove use of deprecated SpatialReference object
  which cannot parse "us-ft" units from older pyproj versions. This
  test works fine with supported StructuredGrid module.
* And for deprecated reference module, tidy up one "to_meter" error